### PR TITLE
Support updating entity custom fields (opt-in only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
 
       - uses: coursier/cache-action@v6
 
-      - name: Run tests
-        run: sbt test scalafmtCheckAll
+      - name: Run tests & linter
+        run: sbt test scalafmtCheckAll "scalafix --check"
 
       - name: Report test results
         if: success() || failure()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  version: 1.0.1
+  version: 1.1.0
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  version: 1.1.0
+  version: 1.1.0-rc.1
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  version: 1.1.0-rc.1
+  version: 1.1.0
 
 jobs:
   publish:

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,5 @@
+rules = [
+  RemoveUnused
+]
+
+RemoveUnused.imports = true

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,9 @@
 name := "capsule-mcp-scala"
 
-ThisBuild / scalaVersion := "3.7.2"
+ThisBuild / scalaVersion := "3.8.3"
 ThisBuild / javacOptions ++= Seq("--release", "17")
+ThisBuild / semanticdbEnabled := true
+ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 ThisBuild / organization := "com.zestia"
 ThisBuild / organizationName := "Zestia Ltd"
 ThisBuild / startYear := Some(2026)
@@ -14,10 +16,11 @@ lazy val root = (project in file("."))
   .enablePlugins(ParadoxSitePlugin, GhpagesPlugin)
   .settings(
     name := "capsule-mcp-scala",
-    scalacOptions ++= Seq("-experimental", "-Xmax-inlines:128"),
+    scalacOptions ++= Seq("-experimental", "-Xmax-inlines:128", "-Wunused:imports"),
     libraryDependencies ++= Seq(
       // MCP Scala SDK
-      "com.tjclp" %% "fast-mcp-scala" % "0.2.1",
+      "com.tjclp" %% "fast-mcp-scala" % "0.3.1",
+      "tools.jackson.core" % "jackson-databind" % "3.0.3",
 
       // ZIO Core
       "dev.zio" %% "zio" % "2.1.22",

--- a/project.scala
+++ b/project.scala
@@ -1,7 +1,8 @@
-//> using scala 3.7.2
+//> using scala 3.8.3
 //> using jvm 17
 //> using options -experimental -Xmax-inlines:128
-//> using dep com.tjclp::fast-mcp-scala:0.2.1
+//> using dep com.tjclp::fast-mcp-scala:0.3.1
+//> using dep tools.jackson.core:jackson-databind:3.0.3
 //> using dep dev.zio::zio:2.1.22
 //> using dep dev.zio::zio-json:0.7.45
 //> using dep com.softwaremill.sttp.client3::core:3.11.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,7 @@
-// formatting
+// formatting/linting
 addSbtPlugin("com.github.sbt" % "sbt-header" % "5.11.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.2")
 
 // documentation
 addSbtPlugin("com.github.sbt" % "sbt-ghpages" % "0.8.0")

--- a/src/main/scala/com/zestia/capsulemcp/model/FieldValue.scala
+++ b/src/main/scala/com/zestia/capsulemcp/model/FieldValue.scala
@@ -16,6 +16,9 @@
 
 package com.zestia.capsulemcp.model
 
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.{DeserializationContext, JsonNode, ValueDeserializer}
+import tools.jackson.databind.annotation.JsonDeserialize
 import zio.json.*
 import zio.json.ast.Json
 import scala.util.Try
@@ -87,3 +90,29 @@ final case class FieldValueNumber(id: Long, value: Long, definition: FieldDefini
 final case class FieldValueBoolean(id: Long, value: Boolean, definition: FieldDefinition) extends FieldValue
     derives JsonDecoder,
       JsonEncoder
+
+@JsonDeserialize(`using` = classOf[FieldValueUpdateDeserializer])
+class FieldValueUpdate(val definition: Long, val value: Json)
+
+object FieldValueUpdate:
+  given JsonEncoder[FieldValueUpdate] = JsonEncoder[Json].contramap { fvu =>
+    Json.Obj("definition" -> Json.Num(fvu.definition), "value" -> fvu.value)
+  }
+
+class FieldValueUpdateDeserializer extends ValueDeserializer[FieldValueUpdate]:
+
+  // Jackson-style deserialization needed by fast-mcp-scala to read Tool argument payloads
+  override def deserialize(p: JsonParser, ctx: DeserializationContext): FieldValueUpdate =
+    val node: JsonNode = ctx.readTree(p)
+
+    val definition = node.get("definition").asLong()
+    val valueNode = node.get("value")
+    val value = {
+      if valueNode.isNull then throw new IllegalArgumentException("field.value cannot be null")
+      else if valueNode.isString then Json.Str(valueNode.asString())
+      else if valueNode.isBoolean then Json.Bool(valueNode.asBoolean())
+      else if valueNode.isNumber then Json.Num(valueNode.decimalValue())
+      else throw new IllegalArgumentException(s"Unsupported value type: ${valueNode.getNodeType}")
+    }
+
+    FieldValueUpdate(definition, value)

--- a/src/main/scala/com/zestia/capsulemcp/model/FieldValue.scala
+++ b/src/main/scala/com/zestia/capsulemcp/model/FieldValue.scala
@@ -95,6 +95,7 @@ final case class FieldValueBoolean(id: Long, value: Boolean, definition: FieldDe
 class FieldValueUpdate(val definition: Long, val value: Json)
 
 object FieldValueUpdate:
+
   given JsonEncoder[FieldValueUpdate] = JsonEncoder[Json].contramap { fvu =>
     Json.Obj("definition" -> Json.Num(fvu.definition), "value" -> fvu.value)
   }

--- a/src/main/scala/com/zestia/capsulemcp/model/filter/Condition.scala
+++ b/src/main/scala/com/zestia/capsulemcp/model/filter/Condition.scala
@@ -16,14 +16,12 @@
 
 package com.zestia.capsulemcp.model.filter
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer, JsonNode}
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import sttp.tapir.Schema.annotations.description
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.{DeserializationContext, JsonNode, ValueDeserializer}
+import tools.jackson.databind.annotation.JsonDeserialize
 import zio.json.ast.Json
 import zio.json.{JsonDecoder, JsonEncoder}
 
-import scala.util.Try
 
 /**
  * See <a href="https://developer.capsulecrm.com/v2/reference/filters"</a>
@@ -91,26 +89,26 @@ object Condition:
       )
     }
 
-class ConditionDeserializer extends JsonDeserializer[Condition]:
+class ConditionDeserializer extends ValueDeserializer[Condition]:
 
   // Jackson-style deserialization needed by fast-mcp-scala to read Tool argument payloads
   override def deserialize(p: JsonParser, context: DeserializationContext): Condition =
-    val node: JsonNode = p.getCodec.readTree(p)
+    val node: JsonNode = context.readTree(p)
 
-    val field = node.get("field").asText()
-    val operator = node.get("operator").asText()
+    val field = node.get("field").asString()
+    val operator = node.get("operator").asString()
     val valueNode = node.get("value")
 
     if (valueNode.isNull) {
       StringCondition(field, operator, None)
-    } else if (valueNode.isTextual) {
-      StringCondition(field, operator, Some(valueNode.asText()))
+    } else if (valueNode.isString) {
+      StringCondition(field, operator, Some(valueNode.asString()))
     } else if (valueNode.isNumber) {
       NumberCondition(field, operator, valueNode.asLong())
     } else if (valueNode.isBoolean) {
       BooleanCondition(field, operator, valueNode.asBoolean())
     } else if (valueNode.isObject) {
-      val currency = valueNode.get("currency").asText()
+      val currency = valueNode.get("currency").asString()
       val amount = valueNode.get("amount").asDouble()
       MoneyCondition(field, operator, MoneyValue(currency, amount))
     } else {

--- a/src/main/scala/com/zestia/capsulemcp/model/filter/Condition.scala
+++ b/src/main/scala/com/zestia/capsulemcp/model/filter/Condition.scala
@@ -22,7 +22,6 @@ import tools.jackson.databind.annotation.JsonDeserialize
 import zio.json.ast.Json
 import zio.json.{JsonDecoder, JsonEncoder}
 
-
 /**
  * See <a href="https://developer.capsulecrm.com/v2/reference/filters"</a>
  */

--- a/src/main/scala/com/zestia/capsulemcp/model/filter/Filter.scala
+++ b/src/main/scala/com/zestia/capsulemcp/model/filter/Filter.scala
@@ -17,7 +17,6 @@
 package com.zestia.capsulemcp.model.filter
 
 import com.zestia.capsulemcp.model.*
-import sttp.tapir.Schema.annotations.*
 import zio.json.*
 
 /**

--- a/src/main/scala/com/zestia/capsulemcp/server/McpServer.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/McpServer.scala
@@ -28,9 +28,9 @@ import com.zestia.capsulemcp.server.schemas.*
 import com.zestia.capsulemcp.server.tools.*
 import com.zestia.capsulemcp.server.tools.ActivityTools.listActivities
 import com.zestia.capsulemcp.server.tools.ContactTools.*
-import com.zestia.capsulemcp.server.tools.ProjectTools.*
+import com.zestia.capsulemcp.server.tools.ProjectTools.{listProjects, updateProject}
 import com.zestia.capsulemcp.server.tools.TaskTools.listTasks
-import com.zestia.capsulemcp.server.tools.OpportunityTools.*
+import com.zestia.capsulemcp.server.tools.OpportunityTools.{calculateValueOfOpportunities, listOpportunities, updateOpportunity}
 import com.zestia.capsulemcp.util.{FileLogger, FileLogging, Version}
 import sttp.tapir.generic.auto.*
 import zio.*
@@ -67,64 +67,101 @@ trait BaseMcpServer:
     )
   )
 
+  private def registerManualTool(
+      server: FastMcpServer,
+      name: String,
+      description: String,
+      fn: Map[String, Any] => Any,
+      schema: String,
+      annotations: Option[ToolAnnotations]
+  ): ZIO[Any, Throwable, Unit] =
+    server
+      .tool(
+        name = name,
+        description = Some(description),
+        handler = (args, _) => ZIO.succeed(fn(args)),
+        inputSchema = ToolInputSchema.unsafeFromJsonString(schema),
+        annotations = annotations
+      )
+      .unit
+
   private[server] def registerManualTools(server: FastMcpServer): ZIO[Any, Throwable, Unit] =
     for
-      _ <- server.tool(
-        name = "list_tasks",
-        description = Some(
-          "List Tasks with basic filtering ability. By default only Tasks with a status of 'OPEN' are returned."
-        ),
-        handler = (args, _) => ZIO.succeed(MapToFunctionMacro.callByMap(listTasks)(args)),
-        inputSchema = ToolInputSchema.unsafeFromJsonString(TaskSchemas.listTasksSchema),
-        annotations = readOnlyAnnotations
+      _ <- registerManualTool(
+        server,
+        "list_tasks",
+        "List Tasks with basic filtering ability. By default only Tasks with a status of 'OPEN' are returned.",
+        MapToFunctionMacro.callByMap(listTasks),
+        TaskSchemas.listTasksSchema,
+        readOnlyAnnotations
       )
-      _ <- server.tool(
-        name = "list_activities",
-        description = Some("List Activities with basic filtering ability"),
-        handler = (args, _) => ZIO.succeed(MapToFunctionMacro.callByMap(listActivities)(args)),
-        inputSchema = ToolInputSchema.unsafeFromJsonString(ActivitySchemas.filterSchema),
-        annotations = readOnlyAnnotations
+      _ <- registerManualTool(
+        server,
+        "list_activities",
+        "List Activities with basic filtering ability",
+        MapToFunctionMacro.callByMap(listActivities),
+        ActivitySchemas.filterSchema,
+        readOnlyAnnotations
       )
-      _ <- server.tool(
-        name = "list_contacts",
-        description = Some("List Contacts with comprehensive filtering ability"),
-        handler = (args, _) => ZIO.succeed(MapToFunctionMacro.callByMap(listContacts)(args)),
-        inputSchema = ToolInputSchema.unsafeFromJsonString(ContactSchemas.filterSchema),
-        annotations = readOnlyAnnotations
+      _ <- registerManualTool(
+        server,
+        "list_contacts",
+        "List Contacts with comprehensive filtering ability",
+        MapToFunctionMacro.callByMap(listContacts),
+        ContactSchemas.filterSchema,
+        readOnlyAnnotations
       )
-      _ <- server.tool(
-        name = "list_projects",
-        description = Some(
-          "List Projects with comprehensive filtering ability. Any references to kase/case are internal/legacy names for Projects"
-        ),
-        handler = (args, _) => ZIO.succeed(MapToFunctionMacro.callByMap(listProjects)(args)),
-        inputSchema = ToolInputSchema.unsafeFromJsonString(ProjectSchemas.filterSchema),
-        annotations = readOnlyAnnotations
+      _ <- registerManualTool(
+        server,
+        "list_projects",
+        "List Projects with comprehensive filtering ability. Any references to kase/case are internal/legacy names for Projects",
+        MapToFunctionMacro.callByMap(listProjects),
+        ProjectSchemas.filterSchema,
+        readOnlyAnnotations
       )
-      _ <- server.tool(
-        name = "list_opportunities",
-        description = Some("List Opportunities with comprehensive filtering ability"),
-        handler = (args, _) => ZIO.succeed(MapToFunctionMacro.callByMap(listOpportunities)(args)),
-        inputSchema = ToolInputSchema.unsafeFromJsonString(OpportunitySchemas.filterSchema),
-        annotations = readOnlyAnnotations
+      _ <- registerManualTool(
+        server,
+        "list_opportunities",
+        "List Opportunities with comprehensive filtering ability",
+        MapToFunctionMacro.callByMap(listOpportunities),
+        OpportunitySchemas.filterSchema,
+        readOnlyAnnotations
       )
-      _ <- server.tool(
-        name = "calculate_value_of_opportunities",
-        description = Some("Get Total & Projected Values for Opportunities with comprehensive filtering ability"),
-        handler = (args, _) => ZIO.succeed(MapToFunctionMacro.callByMap(calculateValueOfOpportunities)(args)),
-        inputSchema = ToolInputSchema.unsafeFromJsonString(OpportunitySchemas.filterSchema),
-        annotations = readOnlyAnnotations
+      _ <- registerManualTool(
+        server,
+        "calculate_value_of_opportunities",
+        "Get Total & Projected Values for Opportunities with comprehensive filtering ability",
+        MapToFunctionMacro.callByMap(calculateValueOfOpportunities),
+        OpportunitySchemas.filterSchema,
+        readOnlyAnnotations
       )
       _ <- ZIO.when(writeToolsEnabled) {
-        server.tool(
-          name = "update_contact",
-          description = Some(
-            "Update a Contact. Only adding/updating custom fields is currently supported. Deleting is NOT allowed but updates will overwrite existing values."
-          ),
-          handler = (args, _) => ZIO.succeed(MapToFunctionMacro.callByMap(updateContact)(args)),
-          inputSchema = ToolInputSchema.unsafeFromJsonString(ContactSchemas.updateContactSchema),
-          annotations = writeAnnotations
-        )
+        for
+          _ <- registerManualTool(
+            server,
+            "update_contact",
+            "Update a Contact. Only adding/updating custom fields is currently supported. Deleting is NOT allowed but updates will overwrite existing values.",
+            MapToFunctionMacro.callByMap(updateContact),
+            ContactSchemas.updateContactSchema,
+            writeAnnotations
+          )
+          _ <- registerManualTool(
+            server,
+            "update_opportunity",
+            "Update an Opportunity. Only adding/updating custom fields is currently supported. Deleting is NOT allowed but updates will overwrite existing values.",
+            MapToFunctionMacro.callByMap(updateOpportunity),
+            OpportunitySchemas.updateOpportunitySchema,
+            writeAnnotations
+          )
+          _ <- registerManualTool(
+            server,
+            "update_project",
+            "Update a Project. Only adding/updating custom fields is currently supported. Deleting is NOT allowed but updates will overwrite existing values.",
+            MapToFunctionMacro.callByMap(updateProject),
+            ProjectSchemas.updateProjectSchema,
+            writeAnnotations
+          )
+        yield ()
       }
     yield ()
 

--- a/src/main/scala/com/zestia/capsulemcp/server/McpServer.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/McpServer.scala
@@ -16,6 +16,8 @@
 
 package com.zestia.capsulemcp.server
 
+import com.tjclp.fastmcp.ToolInputSchema
+import com.tjclp.fastmcp.core.ToolAnnotations
 import com.tjclp.fastmcp.macros.MapToFunctionMacro
 import com.tjclp.fastmcp.macros.RegistrationMacro.*
 import com.tjclp.fastmcp.server.FastMcpServer
@@ -29,44 +31,41 @@ import com.zestia.capsulemcp.server.tools.ContactTools.*
 import com.zestia.capsulemcp.server.tools.ProjectTools.*
 import com.zestia.capsulemcp.server.tools.TaskTools.listTasks
 import com.zestia.capsulemcp.server.tools.OpportunityTools.*
-import com.zestia.capsulemcp.service.CapsuleHttpClient.*
 import com.zestia.capsulemcp.util.{FileLogger, FileLogging, Version}
 import sttp.tapir.generic.auto.*
 import zio.*
-import zio.json.*
 
-object McpServer extends ZIOAppDefault with FileLogging:
+trait BaseMcpServer:
+  protected[server] def writeToolsEnabled: Boolean
 
-  override def run =
-    for
-      _ <- ZIO.attempt {
-        FileLogger.init()
-        logger.info(s"MCP Server starting... version ${Version.current}")
-      }
-      // Create server instance
-      server <- ZIO.succeed(FastMcpServer("McpServer"))
-      // Process tools using the scanAnnotations macro extension method
-      _ <- ZIO.attempt {
-        registerAnnotatedTools(server)
-      }
-      // Manually register tools with custom schemas
-      _ <- registerManualTools(server)
-      // Run the server
-      _ <- server.runStdio()
-    yield ()
+  private[server] def registerAnnotatedTools(server: FastMcpServer): Unit =
+    server.scanAnnotations[OpportunityTools.type]
+    server.scanAnnotations[ContactTools.type]
+    server.scanAnnotations[ProjectTools.type]
+    server.scanAnnotations[CustomFieldTools.type]
+    server.scanAnnotations[TagTools.type]
+    server.scanAnnotations[UserTools.type]
+    server.scanAnnotations[TeamTools.type]
+    server.scanAnnotations[TrackTools.type]
+    server.scanAnnotations[ActivityTools.type]
 
-  private[server] def registerAnnotatedTools(server: FastMcpServer): FastMcpServer =
-    // This macro finds all methods with @Tool, @Prompt or @Resource annotations and registers them with the server
-    server
-      .scanAnnotations[OpportunityTools.type]
-      .scanAnnotations[ContactTools.type]
-      .scanAnnotations[ProjectTools.type]
-      .scanAnnotations[CustomFieldTools.type]
-      .scanAnnotations[TagTools.type]
-      .scanAnnotations[UserTools.type]
-      .scanAnnotations[TeamTools.type]
-      .scanAnnotations[TrackTools.type]
-      .scanAnnotations[ActivityTools.type]
+  private val readOnlyAnnotations = Some(
+    ToolAnnotations(
+      readOnlyHint = Some(true),
+      idempotentHint = Some(true),
+      destructiveHint = Some(false),
+      openWorldHint = Some(true)
+    )
+  )
+
+  private val writeAnnotations = Some(
+    ToolAnnotations(
+      readOnlyHint = Some(false),
+      idempotentHint = Some(true),
+      destructiveHint = Some(true),
+      openWorldHint = Some(true)
+    )
+  )
 
   private[server] def registerManualTools(server: FastMcpServer): ZIO[Any, Throwable, Unit] =
     for
@@ -76,19 +75,22 @@ object McpServer extends ZIOAppDefault with FileLogging:
           "List Tasks with basic filtering ability. By default only Tasks with a status of 'OPEN' are returned."
         ),
         handler = (args, _) => ZIO.succeed(MapToFunctionMacro.callByMap(listTasks)(args)),
-        inputSchema = Right(TaskSchemas.listTasksSchema)
+        inputSchema = ToolInputSchema.unsafeFromJsonString(TaskSchemas.listTasksSchema),
+        annotations = readOnlyAnnotations
       )
       _ <- server.tool(
         name = "list_activities",
         description = Some("List Activities with basic filtering ability"),
         handler = (args, _) => ZIO.succeed(MapToFunctionMacro.callByMap(listActivities)(args)),
-        inputSchema = Right(ActivitySchemas.filterSchema)
+        inputSchema = ToolInputSchema.unsafeFromJsonString(ActivitySchemas.filterSchema),
+        annotations = readOnlyAnnotations
       )
       _ <- server.tool(
         name = "list_contacts",
         description = Some("List Contacts with comprehensive filtering ability"),
         handler = (args, _) => ZIO.succeed(MapToFunctionMacro.callByMap(listContacts)(args)),
-        inputSchema = Right(ContactSchemas.filterSchema)
+        inputSchema = ToolInputSchema.unsafeFromJsonString(ContactSchemas.filterSchema),
+        annotations = readOnlyAnnotations
       )
       _ <- server.tool(
         name = "list_projects",
@@ -96,18 +98,55 @@ object McpServer extends ZIOAppDefault with FileLogging:
           "List Projects with comprehensive filtering ability. Any references to kase/case are internal/legacy names for Projects"
         ),
         handler = (args, _) => ZIO.succeed(MapToFunctionMacro.callByMap(listProjects)(args)),
-        inputSchema = Right(ProjectSchemas.filterSchema)
+        inputSchema = ToolInputSchema.unsafeFromJsonString(ProjectSchemas.filterSchema),
+        annotations = readOnlyAnnotations
       )
       _ <- server.tool(
         name = "list_opportunities",
         description = Some("List Opportunities with comprehensive filtering ability"),
         handler = (args, _) => ZIO.succeed(MapToFunctionMacro.callByMap(listOpportunities)(args)),
-        inputSchema = Right(OpportunitySchemas.filterSchema)
+        inputSchema = ToolInputSchema.unsafeFromJsonString(OpportunitySchemas.filterSchema),
+        annotations = readOnlyAnnotations
       )
       _ <- server.tool(
         name = "calculate_value_of_opportunities",
         description = Some("Get Total & Projected Values for Opportunities with comprehensive filtering ability"),
         handler = (args, _) => ZIO.succeed(MapToFunctionMacro.callByMap(calculateValueOfOpportunities)(args)),
-        inputSchema = Right(OpportunitySchemas.filterSchema)
+        inputSchema = ToolInputSchema.unsafeFromJsonString(OpportunitySchemas.filterSchema),
+        annotations = readOnlyAnnotations
       )
+      _ <- ZIO.when(writeToolsEnabled) {
+        server.tool(
+          name = "update_contact",
+          description = Some(
+            "Update a Contact. Only adding/updating custom fields is currently supported. Deleting is NOT allowed but updates will overwrite existing values."
+          ),
+          handler = (args, _) => ZIO.succeed(MapToFunctionMacro.callByMap(updateContact)(args)),
+          inputSchema = ToolInputSchema.unsafeFromJsonString(ContactSchemas.updateContactSchema),
+          annotations = writeAnnotations
+        )
+      }
+    yield ()
+
+object McpServer extends ZIOAppDefault with FileLogging with BaseMcpServer:
+
+  override protected[server] def writeToolsEnabled: Boolean =
+    sys.env.get("ENABLE_WRITE_TOOLS").contains("true")
+
+  override def run: ZIO[Any, Throwable, Unit] =
+    for
+      _ <- ZIO.attempt {
+        FileLogger.init()
+        logger.info(s"MCP Server starting... version ${Version.current}")
+      }
+      // Create server instance
+      server <- ZIO.succeed(FastMcpServer("CapsuleMcpServer", Version.current))
+      // Process tools using the scanAnnotations macro extension method
+      _ <- ZIO.attempt {
+        registerAnnotatedTools(server)
+      }
+      // Manually register tools with custom schemas
+      _ <- registerManualTools(server)
+      // Run the server
+      _ <- server.runStdio()
     yield ()

--- a/src/main/scala/com/zestia/capsulemcp/server/McpServer.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/McpServer.scala
@@ -30,7 +30,11 @@ import com.zestia.capsulemcp.server.tools.ActivityTools.listActivities
 import com.zestia.capsulemcp.server.tools.ContactTools.*
 import com.zestia.capsulemcp.server.tools.ProjectTools.{listProjects, updateProject}
 import com.zestia.capsulemcp.server.tools.TaskTools.listTasks
-import com.zestia.capsulemcp.server.tools.OpportunityTools.{calculateValueOfOpportunities, listOpportunities, updateOpportunity}
+import com.zestia.capsulemcp.server.tools.OpportunityTools.{
+  calculateValueOfOpportunities,
+  listOpportunities,
+  updateOpportunity
+}
 import com.zestia.capsulemcp.util.{FileLogger, FileLogging, Version}
 import sttp.tapir.generic.auto.*
 import zio.*

--- a/src/main/scala/com/zestia/capsulemcp/server/schemas/ContactSchemas.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/schemas/ContactSchemas.scala
@@ -17,6 +17,7 @@
 package com.zestia.capsulemcp.server.schemas
 
 import com.zestia.capsulemcp.server.schemas.SchemaTypes.*
+import io.circe.*
 
 /**
  * JSON Schemas for Contact-related Tools
@@ -88,3 +89,34 @@ object ContactSchemas extends HasFilterSchema with HasCustomFieldFilterFields:
       isPattern = true
     )
   ) ++ customFieldFilterFields
+
+  val updateContactSchema: String =
+    SchemaBuilders.objectSchema(
+      Map(
+        "id" -> SchemaBuilders.integer("Contact ID"),
+        "fields" -> Json.obj(
+          "type" -> Json.fromString("array"),
+          "description" -> Json.fromString(
+            "Custom field values to update or add. Deleting is NOT allowed but updates will overwrite existing values."
+          ),
+          "items" -> Json.obj(
+            "type" -> Json.fromString("object"),
+            "properties" -> Json.obj(
+              "definition" -> SchemaBuilders.integer("Field definition ID"),
+              "value" -> Json.obj(
+                "description" -> Json.fromString(
+                  "Value type depends on the custom field definition: text/list/link → string; date → string YYYY-MM-DD; multiselectlist → semicolon-delimited string; boolean → boolean; number → string or number. List values must match predefined options. Link values may include placeholders: {id}, {name}, {email}, {phone}, {phone[Mobile]}, {custom[field name]}"
+                ),
+                "oneOf" -> Json.arr(
+                  Json.obj("type" -> Json.fromString("string")),
+                  Json.obj("type" -> Json.fromString("boolean")),
+                  Json.obj("type" -> Json.fromString("number"))
+                )
+              )
+            ),
+            "required" -> Json.arr(Json.fromString("definition"), Json.fromString("value"))
+          )
+        )
+      ),
+      required = List("id", "fields")
+    )

--- a/src/main/scala/com/zestia/capsulemcp/server/schemas/ContactSchemas.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/schemas/ContactSchemas.scala
@@ -17,7 +17,6 @@
 package com.zestia.capsulemcp.server.schemas
 
 import com.zestia.capsulemcp.server.schemas.SchemaTypes.*
-import io.circe.*
 
 /**
  * JSON Schemas for Contact-related Tools
@@ -90,33 +89,4 @@ object ContactSchemas extends HasFilterSchema with HasCustomFieldFilterFields:
     )
   ) ++ customFieldFilterFields
 
-  val updateContactSchema: String =
-    SchemaBuilders.objectSchema(
-      Map(
-        "id" -> SchemaBuilders.integer("Contact ID"),
-        "fields" -> Json.obj(
-          "type" -> Json.fromString("array"),
-          "description" -> Json.fromString(
-            "Custom field values to update or add. Deleting is NOT allowed but updates will overwrite existing values."
-          ),
-          "items" -> Json.obj(
-            "type" -> Json.fromString("object"),
-            "properties" -> Json.obj(
-              "definition" -> SchemaBuilders.integer("Field definition ID"),
-              "value" -> Json.obj(
-                "description" -> Json.fromString(
-                  "Value type depends on the custom field definition: text/list/link → string; date → string YYYY-MM-DD; multiselectlist → semicolon-delimited string; boolean → boolean; number → string or number. List values must match predefined options. Link values may include placeholders: {id}, {name}, {email}, {phone}, {phone[Mobile]}, {custom[field name]}"
-                ),
-                "oneOf" -> Json.arr(
-                  Json.obj("type" -> Json.fromString("string")),
-                  Json.obj("type" -> Json.fromString("boolean")),
-                  Json.obj("type" -> Json.fromString("number"))
-                )
-              )
-            ),
-            "required" -> Json.arr(Json.fromString("definition"), Json.fromString("value"))
-          )
-        )
-      ),
-      required = List("id", "fields")
-    )
+  val updateContactSchema: String = SchemaBuilders.updateEntitySchema("Contact ID")

--- a/src/main/scala/com/zestia/capsulemcp/server/schemas/HasFilterSchema.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/schemas/HasFilterSchema.scala
@@ -17,7 +17,6 @@
 package com.zestia.capsulemcp.server.schemas
 
 import com.zestia.capsulemcp.server.schemas.SchemaTypes.*
-import io.circe.*
 
 trait HasFilterSchema:
   /**

--- a/src/main/scala/com/zestia/capsulemcp/server/schemas/OpportunitySchemas.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/schemas/OpportunitySchemas.scala
@@ -57,3 +57,5 @@ object OpportunitySchemas extends HasFilterSchema with HasCustomFieldFilterField
     DateFilterField("expectedCloseOn", "Expected date close on"),
     DateFilterField("lastContactedOn", "Last contacted date")
   ) ++ customFieldFilterFields
+
+  val updateOpportunitySchema: String = SchemaBuilders.updateEntitySchema("Opportunity ID")

--- a/src/main/scala/com/zestia/capsulemcp/server/schemas/ProjectSchemas.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/schemas/ProjectSchemas.scala
@@ -48,3 +48,5 @@ object ProjectSchemas extends HasFilterSchema with HasCustomFieldFilterFields:
     DateFilterField("expectedCloseOn", "Expected date close on"),
     DateFilterField("startOn", "Start on date")
   ) ++ customFieldFilterFields
+
+  val updateProjectSchema: String = SchemaBuilders.updateEntitySchema("Project ID")

--- a/src/main/scala/com/zestia/capsulemcp/server/schemas/SchemaBuilders.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/schemas/SchemaBuilders.scala
@@ -98,6 +98,40 @@ object SchemaBuilders:
     )
 
   /**
+   * Build the standard schema for an update tool that only supports updating custom fields
+   */
+  def updateEntitySchema(idDescription: String): String =
+    objectSchema(
+      Map(
+        "id" -> integer(idDescription),
+        "fields" -> Json.obj(
+          "type" -> Json.fromString("array"),
+          "description" -> Json.fromString(
+            "Custom field values to update or add. Deleting is NOT allowed but updates will overwrite existing values."
+          ),
+          "items" -> Json.obj(
+            "type" -> Json.fromString("object"),
+            "properties" -> Json.obj(
+              "definition" -> integer("Field definition ID"),
+              "value" -> Json.obj(
+                "description" -> Json.fromString(
+                  "Value type depends on the custom field definition: text/list/link → string; date → string YYYY-MM-DD; multiselectlist → semicolon-delimited string; boolean → boolean; number → string or number. List values must match predefined options. Link values may include placeholders: {id}, {name}, {email}, {phone}, {phone[Mobile]}, {custom[field name]}"
+                ),
+                "oneOf" -> Json.arr(
+                  Json.obj("type" -> Json.fromString("string")),
+                  Json.obj("type" -> Json.fromString("boolean")),
+                  Json.obj("type" -> Json.fromString("number"))
+                )
+              )
+            ),
+            "required" -> Json.arr(Json.fromString("definition"), Json.fromString("value"))
+          )
+        )
+      ),
+      required = List("id", "fields")
+    )
+
+  /**
    * Build a complete object schema from a map of property names to their schemas
    */
   def objectSchema(properties: Map[String, Json], required: List[String] = List.empty): String =

--- a/src/main/scala/com/zestia/capsulemcp/server/tools/ActivityTools.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/tools/ActivityTools.scala
@@ -16,10 +16,7 @@
 
 package com.zestia.capsulemcp.server.tools
 
-import com.tjclp.fastmcp.macros.MapToFunctionMacro
-import com.tjclp.fastmcp.server.FastMcpServer
 import com.zestia.capsulemcp.model.*
-import com.zestia.capsulemcp.server.schemas.ActivitySchemas
 import zio.*
 import com.tjclp.fastmcp.core.{Param, Tool}
 import com.zestia.capsulemcp.model.filter.Filter
@@ -49,7 +46,11 @@ object ActivityTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Entry#listEntriesForEntity"</a>
    */
-  @Tool(Some("list_entries_for_contact"), Some("List notes, emails and completed tasks for a Contact"))
+  @Tool(Some("list_entries_for_contact"), Some("List notes, emails and completed tasks for a Contact"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def listEntriesForContact(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination],
       @Param("Contact ID") id: Long
@@ -59,7 +60,11 @@ object ActivityTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Entry#listEntriesForEntity"</a>
    */
-  @Tool(Some("list_entries_for_opportunity"), Some("List notes, emails and completed tasks for an Opportunity"))
+  @Tool(Some("list_entries_for_opportunity"), Some("List notes, emails and completed tasks for an Opportunity"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def listEntriesForOpportunity(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination],
       @Param("Opportunity ID") id: Long
@@ -69,7 +74,11 @@ object ActivityTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Entry#listEntriesForEntity"</a>
    */
-  @Tool(Some("list_entries_for_project"), Some("List notes, emails and completed tasks for a Project"))
+  @Tool(Some("list_entries_for_project"), Some("List notes, emails and completed tasks for a Project"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def listEntriesForProject(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination],
       @Param("Project ID") id: Long
@@ -79,7 +88,11 @@ object ActivityTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Entry#showEntry"</a>
    */
-  @Tool(Some("get_entry"), Some("Get an Entry (notes, emails and completed tasks) by ID"))
+  @Tool(Some("get_entry"), Some("Get an Entry (notes, emails and completed tasks) by ID"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def getEntry(
       @Param("Entry ID") id: Long
   ): String =

--- a/src/main/scala/com/zestia/capsulemcp/server/tools/ActivityTools.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/tools/ActivityTools.scala
@@ -46,11 +46,14 @@ object ActivityTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Entry#listEntriesForEntity"</a>
    */
-  @Tool(Some("list_entries_for_contact"), Some("List notes, emails and completed tasks for a Contact"),
+  @Tool(
+    Some("list_entries_for_contact"),
+    Some("List notes, emails and completed tasks for a Contact"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def listEntriesForContact(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination],
       @Param("Contact ID") id: Long
@@ -60,11 +63,14 @@ object ActivityTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Entry#listEntriesForEntity"</a>
    */
-  @Tool(Some("list_entries_for_opportunity"), Some("List notes, emails and completed tasks for an Opportunity"),
+  @Tool(
+    Some("list_entries_for_opportunity"),
+    Some("List notes, emails and completed tasks for an Opportunity"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def listEntriesForOpportunity(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination],
       @Param("Opportunity ID") id: Long
@@ -74,11 +80,14 @@ object ActivityTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Entry#listEntriesForEntity"</a>
    */
-  @Tool(Some("list_entries_for_project"), Some("List notes, emails and completed tasks for a Project"),
+  @Tool(
+    Some("list_entries_for_project"),
+    Some("List notes, emails and completed tasks for a Project"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def listEntriesForProject(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination],
       @Param("Project ID") id: Long
@@ -88,11 +97,14 @@ object ActivityTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Entry#showEntry"</a>
    */
-  @Tool(Some("get_entry"), Some("Get an Entry (notes, emails and completed tasks) by ID"),
+  @Tool(
+    Some("get_entry"),
+    Some("Get an Entry (notes, emails and completed tasks) by ID"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def getEntry(
       @Param("Entry ID") id: Long
   ): String =

--- a/src/main/scala/com/zestia/capsulemcp/server/tools/ContactTools.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/tools/ContactTools.scala
@@ -16,16 +16,15 @@
 
 package com.zestia.capsulemcp.server.tools
 
-import com.zestia.capsulemcp.server.schemas.ContactSchemas
-import com.tjclp.fastmcp.macros.MapToFunctionMacro
-import com.tjclp.fastmcp.server.FastMcpServer
-import com.zestia.capsulemcp.model.*
 import com.tjclp.fastmcp.core.{Param, Tool}
+import com.zestia.capsulemcp.model.*
 import com.zestia.capsulemcp.model.filter.Filter
-import com.zestia.capsulemcp.server.schemas.ActivitySchemas
 import com.zestia.capsulemcp.service.CapsuleHttpClient.*
 import zio.*
 import zio.json.*
+
+private case class UpdateParty(fields: List[FieldValueUpdate]) derives JsonEncoder
+private case class UpdateContactWrapper(party: UpdateParty) derives JsonEncoder
 
 object ContactTools:
 
@@ -43,8 +42,23 @@ object ContactTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Party#showParty"</a>
    */
-  @Tool(Some("get_contact"), Some("Get a Contact"))
-  def getEntry(
+  @Tool(Some("get_contact"), Some("Get a Contact"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
+  def getContact(
       @Param("Contact ID") id: Long
   ): String =
     getRequest[ContactWrapper](s"parties/$id").toJson
+
+  /**
+   * Manually registered tool
+   *
+   * See <a href="https://developer.capsulecrm.com/v2/operations/Party#updateParty"</a>
+   */
+  def updateContact(id: Long, fields: List[FieldValueUpdate]): String =
+    putRequest[ContactWrapper, UpdateContactWrapper](
+      s"parties/$id",
+      UpdateContactWrapper(UpdateParty(fields))
+    ).toJson

--- a/src/main/scala/com/zestia/capsulemcp/server/tools/ContactTools.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/tools/ContactTools.scala
@@ -42,11 +42,14 @@ object ContactTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Party#showParty"</a>
    */
-  @Tool(Some("get_contact"), Some("Get a Contact"),
+  @Tool(
+    Some("get_contact"),
+    Some("Get a Contact"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def getContact(
       @Param("Contact ID") id: Long
   ): String =

--- a/src/main/scala/com/zestia/capsulemcp/server/tools/CustomFieldTools.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/tools/CustomFieldTools.scala
@@ -43,7 +43,11 @@ object CustomFieldTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Custom_Field#showField"</a>
    */
-  @Tool(Some("get_contact_custom_field"), Some("Get Contact Custom Field Definition by ID"))
+  @Tool(Some("get_contact_custom_field"), Some("Get Contact Custom Field Definition by ID"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def getContactCustomField(
       @Param("Custom Field Definition ID") id: Long
   ): String =
@@ -52,7 +56,11 @@ object CustomFieldTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Custom_Field#showField"</a>
    */
-  @Tool(Some("get_opportunity_custom_field"), Some("Get Opportunity Custom Field Definition by ID"))
+  @Tool(Some("get_opportunity_custom_field"), Some("Get Opportunity Custom Field Definition by ID"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def getOpportunityCustomField(
       @Param("Custom Field Definition ID") id: Long
   ): String =
@@ -61,7 +69,11 @@ object CustomFieldTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Custom_Field#showField"</a>
    */
-  @Tool(Some("get_project_custom_field"), Some("Get Project Custom Field Definition by ID"))
+  @Tool(Some("get_project_custom_field"), Some("Get Project Custom Field Definition by ID"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def getProjectCustomField(
       @Param("Custom Field Definition ID") id: Long
   ): String =
@@ -72,7 +84,11 @@ object CustomFieldTools:
    */
   @Tool(
     Some("list_contact_custom_fields"),
-    Some("List Custom Fields defined for Contacts (does not include DataTag fields)")
+    Some("List Custom Fields defined for Contacts (does not include DataTag fields)"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true)
   )
   def listContactCustomFields(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination]
@@ -84,7 +100,11 @@ object CustomFieldTools:
    */
   @Tool(
     Some("list_opportunity_custom_fields"),
-    Some("List Custom Fields defined for Opportunities (does not include DataTag fields)")
+    Some("List Custom Fields defined for Opportunities (does not include DataTag fields)"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true)
   )
   def listOpportunityCustomFields(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination]
@@ -96,7 +116,11 @@ object CustomFieldTools:
    */
   @Tool(
     Some("list_project_custom_fields"),
-    Some("List Custom Fields defined for Projects (does not include DataTag fields)")
+    Some("List Custom Fields defined for Projects (does not include DataTag fields)"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true)
   )
   def listProjectCustomFields(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination]
@@ -105,7 +129,11 @@ object CustomFieldTools:
 
   @Tool(
     Some("list_custom_fields_for_contact_data_tag"),
-    Some("List Custom Fields defined for a Contact DataTag (a type of Tag used to group Custom Fields together)")
+    Some("List Custom Fields defined for a Contact DataTag (a type of Tag used to group Custom Fields together)"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true)
   )
   def listCustomFieldsContactDataTag(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination],
@@ -115,7 +143,11 @@ object CustomFieldTools:
 
   @Tool(
     Some("list_custom_fields_for_opportunity_data_tag"),
-    Some("List Custom Fields defined for an Opportunity DataTag (a type of Tag used to group Custom Fields together)")
+    Some("List Custom Fields defined for an Opportunity DataTag (a type of Tag used to group Custom Fields together)"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true)
   )
   def listCustomFieldsOpportunityDataTag(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination],
@@ -125,7 +157,11 @@ object CustomFieldTools:
 
   @Tool(
     Some("list_custom_fields_for_project_data_tag"),
-    Some("List Custom Fields defined for a Project DataTag (a type of Tag used to group Custom Fields together)")
+    Some("List Custom Fields defined for a Project DataTag (a type of Tag used to group Custom Fields together)"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true)
   ) def listCustomFieldsProjectDataTag(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination],
       @Param("Tag ID") id: Long

--- a/src/main/scala/com/zestia/capsulemcp/server/tools/CustomFieldTools.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/tools/CustomFieldTools.scala
@@ -43,11 +43,14 @@ object CustomFieldTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Custom_Field#showField"</a>
    */
-  @Tool(Some("get_contact_custom_field"), Some("Get Contact Custom Field Definition by ID"),
+  @Tool(
+    Some("get_contact_custom_field"),
+    Some("Get Contact Custom Field Definition by ID"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def getContactCustomField(
       @Param("Custom Field Definition ID") id: Long
   ): String =
@@ -56,11 +59,14 @@ object CustomFieldTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Custom_Field#showField"</a>
    */
-  @Tool(Some("get_opportunity_custom_field"), Some("Get Opportunity Custom Field Definition by ID"),
+  @Tool(
+    Some("get_opportunity_custom_field"),
+    Some("Get Opportunity Custom Field Definition by ID"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def getOpportunityCustomField(
       @Param("Custom Field Definition ID") id: Long
   ): String =
@@ -69,11 +75,14 @@ object CustomFieldTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Custom_Field#showField"</a>
    */
-  @Tool(Some("get_project_custom_field"), Some("Get Project Custom Field Definition by ID"),
+  @Tool(
+    Some("get_project_custom_field"),
+    Some("Get Project Custom Field Definition by ID"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def getProjectCustomField(
       @Param("Custom Field Definition ID") id: Long
   ): String =

--- a/src/main/scala/com/zestia/capsulemcp/server/tools/OpportunityTools.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/tools/OpportunityTools.scala
@@ -20,8 +20,11 @@ import com.tjclp.fastmcp.core.{Param, Tool}
 import com.zestia.capsulemcp.model.filter.Filter
 import com.zestia.capsulemcp.model.*
 import com.zestia.capsulemcp.server.tools.common.ToolParams
-import com.zestia.capsulemcp.service.CapsuleHttpClient.{filterRequest, getRequest}
+import com.zestia.capsulemcp.service.CapsuleHttpClient.{filterRequest, getRequest, putRequest}
 import zio.json.*
+
+private case class UpdateOpportunityFields(fields: List[FieldValueUpdate]) derives JsonEncoder
+private case class UpdateOpportunityWrapper(opportunity: UpdateOpportunityFields) derives JsonEncoder
 
 object OpportunityTools:
 
@@ -187,3 +190,14 @@ object OpportunityTools:
       @Param("Lost Reason ID") id: Long
   ): String =
     getRequest[LostReasonWrapper](s"lostreasons/$id").toJson
+
+  /**
+   * Manually registered tool
+   *
+   * See <a href="https://developer.capsulecrm.com/v2/operations/Opportunity#updateOpportunity"</a>
+   */
+  def updateOpportunity(id: Long, fields: List[FieldValueUpdate]): String =
+    putRequest[OpportunityWrapper, UpdateOpportunityWrapper](
+      s"opportunities/$id",
+      UpdateOpportunityWrapper(UpdateOpportunityFields(fields))
+    ).toJson

--- a/src/main/scala/com/zestia/capsulemcp/server/tools/OpportunityTools.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/tools/OpportunityTools.scala
@@ -39,7 +39,14 @@ object OpportunityTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Opportunity#showOpportunity"</a>
    */
-  @Tool(Some("get_opportunity"), Some("Get an Opportunity by ID"))
+  @Tool(
+    Some("get_opportunity"),
+    Some("Get an Opportunity by ID"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true)
+  )
   def getOpportunity(
       @Param("Opportunity ID") id: Long
   ): String =
@@ -57,7 +64,14 @@ object OpportunityTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Pipeline#listPipelines"</a>
    */
-  @Tool(Some("list_pipelines"), Some("List Sales Pipelines for Opportunities, with optional searching by name"))
+  @Tool(
+    Some("list_pipelines"),
+    Some("List Sales Pipelines for Opportunities, with optional searching by name"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true)
+  )
   def listPipelines(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination],
       @Param("Search Pipelines by name", required = false) query: Option[String] = None
@@ -71,7 +85,14 @@ object OpportunityTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Pipeline#showPipeline"</a>
    */
-  @Tool(Some("get_pipeline"), Some("Get a Pipeline by ID"))
+  @Tool(
+    Some("get_pipeline"),
+    Some("Get a Pipeline by ID"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true)
+  )
   def getPipeline(
       @Param("Pipeline ID") id: Long
   ): String =
@@ -84,7 +105,11 @@ object OpportunityTools:
     Some("list_milestones"),
     Some(
       "List Milestones across all Sales Pipelines. To list Milestones on a specific Pipeline, use `list_milestones_by_pipeline`"
-    )
+    ),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true)
   )
   def listMilestones(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination]
@@ -94,7 +119,14 @@ object OpportunityTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Milestone#showMilestone"</a>
    */
-  @Tool(Some("get_milestone"), Some("Get a Milestone by ID"))
+  @Tool(
+    Some("get_milestone"),
+    Some("Get a Milestone by ID"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true)
+  )
   def getMilestone(
       @Param("Milestone ID") id: Long
   ): String =
@@ -103,7 +135,14 @@ object OpportunityTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Milestone#listMilestonesForPipeline"</a>
    */
-  @Tool(Some("list_milestones_by_pipeline"), Some("List Milestones associated with a Sales Pipeline"))
+  @Tool(
+    Some("list_milestones_by_pipeline"),
+    Some("List Milestones associated with a Sales Pipeline"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true)
+  )
   def listMilestonesByPipelineId(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination],
       @Param("Sales Pipeline ID") pipelineId: Long
@@ -117,7 +156,11 @@ object OpportunityTools:
     Some("list_lost_reasons"),
     Some(
       "List Lost Reasons, with optional searching by name. Lost Reasons allow users to record the reason an Opportunity is lost"
-    )
+    ),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true)
   )
   def listLostReasons(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination],
@@ -132,7 +175,14 @@ object OpportunityTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Lost_Reason#showLostReason"</a>
    */
-  @Tool(Some("get_lost_reason"), Some("Get a Lost Reason by ID"))
+  @Tool(
+    Some("get_lost_reason"),
+    Some("Get a Lost Reason by ID"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true)
+  )
   def getLostReason(
       @Param("Lost Reason ID") id: Long
   ): String =

--- a/src/main/scala/com/zestia/capsulemcp/server/tools/ProjectTools.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/tools/ProjectTools.scala
@@ -39,11 +39,14 @@ object ProjectTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Project#showProject"</a>
    */
-  @Tool(Some("get_project"), Some("Get a Project by ID"),
+  @Tool(
+    Some("get_project"),
+    Some("Get a Project by ID"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def getProject(
       @Param("Project ID") id: Long
   ): String =
@@ -52,11 +55,14 @@ object ProjectTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Board#listBoards"</a>
    */
-  @Tool(Some("list_boards"), Some("List Boards for Projects, with optional searching by name"),
+  @Tool(
+    Some("list_boards"),
+    Some("List Boards for Projects, with optional searching by name"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def listBoards(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination],
       @Param("Search Boards by name", required = false) query: Option[String] = None
@@ -70,11 +76,14 @@ object ProjectTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Board#showBoard"</a>
    */
-  @Tool(Some("get_board"), Some("Get a Project Board by ID"),
+  @Tool(
+    Some("get_board"),
+    Some("Get a Project Board by ID"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def getBoard(
       @Param("Board ID") id: Long
   ): String =
@@ -99,11 +108,14 @@ object ProjectTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Stage#showStage"</a>
    */
-  @Tool(Some("get_stage"), Some("Get a Project Stage by ID"),
+  @Tool(
+    Some("get_stage"),
+    Some("Get a Project Stage by ID"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def getStage(
       @Param("Stage ID") id: Long
   ): String =
@@ -112,11 +124,14 @@ object ProjectTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Stage#listStagesForBoard"</a>
    */
-  @Tool(Some("list_stages_by_board"), Some("List Stages associated with a Project Board"),
+  @Tool(
+    Some("list_stages_by_board"),
+    Some("List Stages associated with a Project Board"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def listStagesByBoardId(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination],
       @Param("Board ID") boardId: Long

--- a/src/main/scala/com/zestia/capsulemcp/server/tools/ProjectTools.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/tools/ProjectTools.scala
@@ -20,8 +20,11 @@ import com.tjclp.fastmcp.core.{Param, Tool}
 import com.zestia.capsulemcp.model.filter.Filter
 import com.zestia.capsulemcp.model.*
 import com.zestia.capsulemcp.server.tools.common.ToolParams
-import com.zestia.capsulemcp.service.CapsuleHttpClient.{filterRequest, getRequest}
+import com.zestia.capsulemcp.service.CapsuleHttpClient.{filterRequest, getRequest, putRequest}
 import zio.json.*
+
+private case class UpdateProjectFields(fields: List[FieldValueUpdate]) derives JsonEncoder
+private case class UpdateProjectWrapper(kase: UpdateProjectFields) derives JsonEncoder
 
 object ProjectTools:
 
@@ -137,3 +140,14 @@ object ProjectTools:
       @Param("Board ID") boardId: Long
   ): String =
     getRequest[StageListWrapper](s"boards/$boardId/stages", pagination).toJson
+
+  /**
+   * Manually registered tool
+   *
+   * See <a href="https://developer.capsulecrm.com/v2/operations/Kase#updateKase"</a>
+   */
+  def updateProject(id: Long, fields: List[FieldValueUpdate]): String =
+    putRequest[ProjectWrapper, UpdateProjectWrapper](
+      s"kases/$id",
+      UpdateProjectWrapper(UpdateProjectFields(fields))
+    ).toJson

--- a/src/main/scala/com/zestia/capsulemcp/server/tools/ProjectTools.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/tools/ProjectTools.scala
@@ -39,7 +39,11 @@ object ProjectTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Project#showProject"</a>
    */
-  @Tool(Some("get_project"), Some("Get a Project by ID"))
+  @Tool(Some("get_project"), Some("Get a Project by ID"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def getProject(
       @Param("Project ID") id: Long
   ): String =
@@ -48,7 +52,11 @@ object ProjectTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Board#listBoards"</a>
    */
-  @Tool(Some("list_boards"), Some("List Boards for Projects, with optional searching by name"))
+  @Tool(Some("list_boards"), Some("List Boards for Projects, with optional searching by name"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def listBoards(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination],
       @Param("Search Boards by name", required = false) query: Option[String] = None
@@ -62,7 +70,11 @@ object ProjectTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Board#showBoard"</a>
    */
-  @Tool(Some("get_board"), Some("Get a Project Board by ID"))
+  @Tool(Some("get_board"), Some("Get a Project Board by ID"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def getBoard(
       @Param("Board ID") id: Long
   ): String =
@@ -73,7 +85,11 @@ object ProjectTools:
    */
   @Tool(
     Some("list_stages"),
-    Some("List Stages across all Project Boards. To list Stages on a specific Board, use `list_stages_by_board_id`")
+    Some("List Stages across all Project Boards. To list Stages on a specific Board, use `list_stages_by_board_id`"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true)
   )
   def listStages(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination]
@@ -83,7 +99,11 @@ object ProjectTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Stage#showStage"</a>
    */
-  @Tool(Some("get_stage"), Some("Get a Project Stage by ID"))
+  @Tool(Some("get_stage"), Some("Get a Project Stage by ID"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def getStage(
       @Param("Stage ID") id: Long
   ): String =
@@ -92,7 +112,11 @@ object ProjectTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Stage#listStagesForBoard"</a>
    */
-  @Tool(Some("list_stages_by_board"), Some("List Stages associated with a Project Board"))
+  @Tool(Some("list_stages_by_board"), Some("List Stages associated with a Project Board"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def listStagesByBoardId(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination],
       @Param("Board ID") boardId: Long

--- a/src/main/scala/com/zestia/capsulemcp/server/tools/TagTools.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/tools/TagTools.scala
@@ -33,11 +33,14 @@ object TagTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Tag#showTag"</a>
    */
-  @Tool(Some("get_contact_tag"), Some("Get Contact Tag Definition by ID"),
+  @Tool(
+    Some("get_contact_tag"),
+    Some("Get Contact Tag Definition by ID"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def getContactTag(
       @Param("Tag ID") id: Long
   ): String =
@@ -46,11 +49,14 @@ object TagTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Tag#showTag"</a>
    */
-  @Tool(Some("get_opportunity_tag"), Some("Get Opportunity Tag Definition by ID"),
+  @Tool(
+    Some("get_opportunity_tag"),
+    Some("Get Opportunity Tag Definition by ID"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def getOpportunityTag(
       @Param("Tag ID") id: Long
   ): String =
@@ -59,11 +65,14 @@ object TagTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Tag#showTag"</a>
    */
-  @Tool(Some("get_project_tag"), Some("Get Project Tag Definition by ID"),
+  @Tool(
+    Some("get_project_tag"),
+    Some("Get Project Tag Definition by ID"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def getProjectTag(
       @Param("Tag ID") id: Long
   ): String =
@@ -72,11 +81,14 @@ object TagTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Tag#listTags"</a>
    */
-  @Tool(Some("list_contact_tags"), Some("List Tags defined for Contacts"),
+  @Tool(
+    Some("list_contact_tags"),
+    Some("List Tags defined for Contacts"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def listContactTags(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination]
   ): String =
@@ -85,11 +97,14 @@ object TagTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Tag#listTags"</a>
    */
-  @Tool(Some("list_opportunity_tags"), Some("List Tags defined for Opportunities"),
+  @Tool(
+    Some("list_opportunity_tags"),
+    Some("List Tags defined for Opportunities"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def listOpportunityTags(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination]
   ): String =
@@ -98,11 +113,14 @@ object TagTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Tag#listTags"</a>
    */
-  @Tool(Some("list_project_tags"), Some("List Tags defined for Projects"),
+  @Tool(
+    Some("list_project_tags"),
+    Some("List Tags defined for Projects"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def listProjectTags(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination]
   ): String =

--- a/src/main/scala/com/zestia/capsulemcp/server/tools/TagTools.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/tools/TagTools.scala
@@ -33,7 +33,11 @@ object TagTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Tag#showTag"</a>
    */
-  @Tool(Some("get_contact_tag"), Some("Get Contact Tag Definition by ID"))
+  @Tool(Some("get_contact_tag"), Some("Get Contact Tag Definition by ID"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def getContactTag(
       @Param("Tag ID") id: Long
   ): String =
@@ -42,7 +46,11 @@ object TagTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Tag#showTag"</a>
    */
-  @Tool(Some("get_opportunity_tag"), Some("Get Opportunity Tag Definition by ID"))
+  @Tool(Some("get_opportunity_tag"), Some("Get Opportunity Tag Definition by ID"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def getOpportunityTag(
       @Param("Tag ID") id: Long
   ): String =
@@ -51,7 +59,11 @@ object TagTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Tag#showTag"</a>
    */
-  @Tool(Some("get_project_tag"), Some("Get Project Tag Definition by ID"))
+  @Tool(Some("get_project_tag"), Some("Get Project Tag Definition by ID"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def getProjectTag(
       @Param("Tag ID") id: Long
   ): String =
@@ -60,7 +72,11 @@ object TagTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Tag#listTags"</a>
    */
-  @Tool(Some("list_contact_tags"), Some("List Tags defined for Contacts"))
+  @Tool(Some("list_contact_tags"), Some("List Tags defined for Contacts"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def listContactTags(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination]
   ): String =
@@ -69,7 +85,11 @@ object TagTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Tag#listTags"</a>
    */
-  @Tool(Some("list_opportunity_tags"), Some("List Tags defined for Opportunities"))
+  @Tool(Some("list_opportunity_tags"), Some("List Tags defined for Opportunities"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def listOpportunityTags(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination]
   ): String =
@@ -78,7 +98,11 @@ object TagTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Tag#listTags"</a>
    */
-  @Tool(Some("list_project_tags"), Some("List Tags defined for Projects"))
+  @Tool(Some("list_project_tags"), Some("List Tags defined for Projects"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def listProjectTags(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination]
   ): String =

--- a/src/main/scala/com/zestia/capsulemcp/server/tools/TaskTools.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/tools/TaskTools.scala
@@ -57,11 +57,14 @@ object TaskTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Task#showTask"</a>
    */
-  @Tool(Some("get_task"), Some("Get a Task by ID"),
+  @Tool(
+    Some("get_task"),
+    Some("Get a Task by ID"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def getTask(
       @Param("Task ID") id: Long
   ): String =

--- a/src/main/scala/com/zestia/capsulemcp/server/tools/TaskTools.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/tools/TaskTools.scala
@@ -16,10 +16,7 @@
 
 package com.zestia.capsulemcp.server.tools
 
-import com.tjclp.fastmcp.macros.MapToFunctionMacro
-import com.tjclp.fastmcp.server.FastMcpServer
 import com.zestia.capsulemcp.model.*
-import com.zestia.capsulemcp.server.schemas.TaskSchemas
 import com.zestia.capsulemcp.service.CapsuleHttpClient.getRequest
 import zio.*
 import zio.json.*
@@ -60,7 +57,11 @@ object TaskTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Task#showTask"</a>
    */
-  @Tool(Some("get_task"), Some("Get a Task by ID"))
+  @Tool(Some("get_task"), Some("Get a Task by ID"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def getTask(
       @Param("Task ID") id: Long
   ): String =

--- a/src/main/scala/com/zestia/capsulemcp/server/tools/TeamTools.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/tools/TeamTools.scala
@@ -26,22 +26,28 @@ object TeamTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Team#listTeams"</a>
    */
-  @Tool(Some("list_teams"), Some("List Teams and team members"),
+  @Tool(
+    Some("list_teams"),
+    Some("List Teams and team members"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def listTeams(): String =
     getRequest[TeamListWrapper]("teams", embed = List("memberships")).toJson
 
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Team#showTeam"</a>
    */
-  @Tool(Some("get_team"), Some("Get a Team by ID"),
+  @Tool(
+    Some("get_team"),
+    Some("Get a Team by ID"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def getTeam(
       @Param("Team ID") id: Long
   ): String =

--- a/src/main/scala/com/zestia/capsulemcp/server/tools/TeamTools.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/tools/TeamTools.scala
@@ -26,14 +26,22 @@ object TeamTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Team#listTeams"</a>
    */
-  @Tool(Some("list_teams"), Some("List Teams and team members"))
+  @Tool(Some("list_teams"), Some("List Teams and team members"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def listTeams(): String =
     getRequest[TeamListWrapper]("teams", embed = List("memberships")).toJson
 
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Team#showTeam"</a>
    */
-  @Tool(Some("get_team"), Some("Get a Team by ID"))
+  @Tool(Some("get_team"), Some("Get a Team by ID"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def getTeam(
       @Param("Team ID") id: Long
   ): String =

--- a/src/main/scala/com/zestia/capsulemcp/server/tools/TrackTools.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/tools/TrackTools.scala
@@ -27,11 +27,14 @@ object TrackTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Track#showTrack"</a>
    */
-  @Tool(Some("get_track"), Some("Get Track by ID"),
+  @Tool(
+    Some("get_track"),
+    Some("Get Track by ID"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def getTrack(
       @Param("Track ID", required = true) id: Long
   ): String =
@@ -43,11 +46,14 @@ object TrackTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Track#listTrack"</a>
    */
-  @Tool(Some("list_tracks_for_contact"), Some("List Tracks for specified Contact"),
+  @Tool(
+    Some("list_tracks_for_contact"),
+    Some("List Tracks for specified Contact"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def listTracksForContact(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination],
       @Param("Contact ID") contactId: Long
@@ -57,11 +63,14 @@ object TrackTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Track#listTrack"</a>
    */
-  @Tool(Some("list_tracks_for_opportunity"), Some("List Tracks for specified Opportunity"),
+  @Tool(
+    Some("list_tracks_for_opportunity"),
+    Some("List Tracks for specified Opportunity"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def listTracksForOpportunity(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination],
       @Param("Opportunity ID") opportunityId: Long
@@ -71,11 +80,14 @@ object TrackTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Track#listTrack"</a>
    */
-  @Tool(Some("list_tracks_for_project"), Some("List Tracks for specified Project"),
+  @Tool(
+    Some("list_tracks_for_project"),
+    Some("List Tracks for specified Project"),
     readOnlyHint = Some(true),
     destructiveHint = Some(false),
     idempotentHint = Some(true),
-    openWorldHint = Some(true))
+    openWorldHint = Some(true)
+  )
   def listTracksForProject(
       @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination],
       @Param("Project ID") projectId: Long

--- a/src/main/scala/com/zestia/capsulemcp/server/tools/TrackTools.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/tools/TrackTools.scala
@@ -20,7 +20,6 @@ import com.tjclp.fastmcp.core.{Param, Tool}
 import com.zestia.capsulemcp.model.{Pagination, TrackListWrapper, TrackWrapper}
 import com.zestia.capsulemcp.server.tools.common.ToolParams
 import com.zestia.capsulemcp.service.CapsuleHttpClient.getRequest
-import sttp.tapir.Schema.annotations.default
 import zio.json.*
 
 object TrackTools:
@@ -28,7 +27,11 @@ object TrackTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Track#showTrack"</a>
    */
-  @Tool(Some("get_track"), Some("Get Track by ID"))
+  @Tool(Some("get_track"), Some("Get Track by ID"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def getTrack(
       @Param("Track ID", required = true) id: Long
   ): String =
@@ -40,29 +43,41 @@ object TrackTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Track#listTrack"</a>
    */
-  @Tool(Some("list_tracks_for_contact"), Some("List Tracks for specified Contact"))
+  @Tool(Some("list_tracks_for_contact"), Some("List Tracks for specified Contact"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def listTracksForContact(
-      @Param(ToolParams.paginationDescription, required = false) pagination: Pagination,
+      @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination],
       @Param("Contact ID") contactId: Long
   ): String =
-    listTracksForEntity("parties", contactId, Option(pagination))
+    listTracksForEntity("parties", contactId, pagination)
 
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Track#listTrack"</a>
    */
-  @Tool(Some("list_tracks_for_opportunity"), Some("List Tracks for specified Opportunity"))
+  @Tool(Some("list_tracks_for_opportunity"), Some("List Tracks for specified Opportunity"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def listTracksForOpportunity(
-      @Param(ToolParams.paginationDescription, required = false) pagination: Pagination,
+      @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination],
       @Param("Opportunity ID") opportunityId: Long
   ): String =
-    listTracksForEntity("opportunities", opportunityId, Option(pagination))
+    listTracksForEntity("opportunities", opportunityId, pagination)
 
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/Track#listTrack"</a>
    */
-  @Tool(Some("list_tracks_for_project"), Some("List Tracks for specified Project"))
+  @Tool(Some("list_tracks_for_project"), Some("List Tracks for specified Project"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true))
   def listTracksForProject(
-      @Param(ToolParams.paginationDescription, required = false) pagination: Pagination,
+      @Param(ToolParams.paginationDescription, required = false) pagination: Option[Pagination],
       @Param("Project ID") projectId: Long
   ): String =
-    listTracksForEntity("kases", projectId, Option(pagination))
+    listTracksForEntity("kases", projectId, pagination)

--- a/src/main/scala/com/zestia/capsulemcp/server/tools/UserTools.scala
+++ b/src/main/scala/com/zestia/capsulemcp/server/tools/UserTools.scala
@@ -26,14 +26,28 @@ object UserTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/User#listUsers"</a>
    */
-  @Tool(Some("list_users"), Some("List Users"))
+  @Tool(
+    Some("list_users"),
+    Some("List Users"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true)
+  )
   def listUsers(): String =
     getRequest[UserListWrapper]("users").toJson
 
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/User#showUser"</a>
    */
-  @Tool(Some("get_user"), Some("Get User by ID"))
+  @Tool(
+    Some("get_user"),
+    Some("Get User by ID"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true)
+  )
   def getUser(
       @Param("User ID") id: Long
   ): String =
@@ -42,6 +56,13 @@ object UserTools:
   /**
    * See <a href="https://developer.capsulecrm.com/v2/operations/User#showCurrentUser"</a>
    */
-  @Tool(Some("get_current_user"), Some("Get the current User"))
+  @Tool(
+    Some("get_current_user"),
+    Some("Get the current User"),
+    readOnlyHint = Some(true),
+    destructiveHint = Some(false),
+    idempotentHint = Some(true),
+    openWorldHint = Some(true)
+  )
   def getCurrentUser(): String =
     getRequest[UserWrapper]("users/current", embed = List("party")).toJson

--- a/src/main/scala/com/zestia/capsulemcp/service/CapsuleHttpClient.scala
+++ b/src/main/scala/com/zestia/capsulemcp/service/CapsuleHttpClient.scala
@@ -108,6 +108,13 @@ trait BaseCapsuleHttpClient extends HttpClient:
       FilterRequestWrapper(filter)
     )
 
+  def putRequest[T: {JsonDecoder, ClassTag}, B: JsonEncoder](
+      path: String,
+      body: B,
+      embed: List[String] = List.empty
+  ): ResponseWrapper[T] =
+    executeRequestWithBody[T, B](Method.PUT, path, None, Map.empty, embed, body)
+
 object CapsuleHttpClient extends BaseCapsuleHttpClient:
 
   private val DEFAULT_CAPSULE_HOST = "https://api.capsulecrm.com"

--- a/src/main/scala/com/zestia/capsulemcp/service/HttpClient.scala
+++ b/src/main/scala/com/zestia/capsulemcp/service/HttpClient.scala
@@ -59,6 +59,11 @@ abstract class HttpClient extends FileLogging:
       }
     } else {
       response.code.code match {
+        case 403 =>
+          logger.warn(s"Forbidden: ${response.body}")
+          throw new RuntimeException(
+            "API error: 403 Forbidden — your Capsule API token does not have write permission."
+          )
         case 404 =>
           logger.warn("Not found")
           throw new RuntimeException("API error: 404 Not Found")

--- a/src/main/scala/com/zestia/capsulemcp/util/Version.scala
+++ b/src/main/scala/com/zestia/capsulemcp/util/Version.scala
@@ -17,4 +17,4 @@
 package com.zestia.capsulemcp.util
 
 object Version:
-  val current = "1.1.0"
+  val current = "1.1.0-rc.1"

--- a/src/main/scala/com/zestia/capsulemcp/util/Version.scala
+++ b/src/main/scala/com/zestia/capsulemcp/util/Version.scala
@@ -17,4 +17,4 @@
 package com.zestia.capsulemcp.util
 
 object Version:
-  val current = "1.0.1"
+  val current = "1.1.0"

--- a/src/main/scala/com/zestia/capsulemcp/util/Version.scala
+++ b/src/main/scala/com/zestia/capsulemcp/util/Version.scala
@@ -17,4 +17,4 @@
 package com.zestia.capsulemcp.util
 
 object Version:
-  val current = "1.1.0-rc.1"
+  val current = "1.1.0"

--- a/src/test/scala/com/zestia/capsulemcp/server/McpServerSpec.scala
+++ b/src/test/scala/com/zestia/capsulemcp/server/McpServerSpec.scala
@@ -10,6 +10,7 @@ import scala.jdk.CollectionConverters.*
 
 object McpServerSpec extends ZIOSpecDefault {
 
+  // TODO: introduce proper integration tests
   def spec: Spec[Any, Throwable] = suite("McpServer")(
     test("registerAnnotatedTools should register all annotated Tools") {
       for {
@@ -27,13 +28,16 @@ object McpServerSpec extends ZIOSpecDefault {
         tools = toolsResult.tools().asScala.toList
       } yield assertTrue(tools.size == 6)
     },
-    test("registerManualTools should register update_contact when write tools are enabled") {
+    test("registerManualTools should register write tools when enabled") {
       for {
         server <- ZIO.succeed(FastMcpServer("TestServer"))
         _ <- new TestMcpServer(writeToolsEnabled = true).registerManualTools(server)
         toolsResult <- server.listTools()
         tools = toolsResult.tools().asScala.toList
-      } yield assertTrue(tools.size == 7) && assertTrue(tools.exists(_.name() == "update_contact"))
+      } yield assertTrue(tools.size == 9) &&
+        assertTrue(tools.exists(_.name() == "update_contact")) &&
+        assertTrue(tools.exists(_.name() == "update_opportunity")) &&
+        assertTrue(tools.exists(_.name() == "update_project"))
     }
   )
 

--- a/src/test/scala/com/zestia/capsulemcp/server/McpServerSpec.scala
+++ b/src/test/scala/com/zestia/capsulemcp/server/McpServerSpec.scala
@@ -14,7 +14,7 @@ object McpServerSpec extends ZIOSpecDefault {
     test("registerAnnotatedTools should register all annotated Tools") {
       for {
         server <- ZIO.succeed(FastMcpServer("TestServer"))
-        _ <- ZIO.succeed(McpServer.registerAnnotatedTools(server))
+        _ <- ZIO.succeed(new TestMcpServer(writeToolsEnabled = false).registerAnnotatedTools(server))
         toolsResult <- server.listTools()
         tools = toolsResult.tools().asScala.toList
       } yield assertTrue(tools.size == 43)
@@ -22,10 +22,20 @@ object McpServerSpec extends ZIOSpecDefault {
     test("registerManualTools should register all manual Tools") {
       for {
         server <- ZIO.succeed(FastMcpServer("TestServer"))
-        _ <- McpServer.registerManualTools(server)
+        _ <- new TestMcpServer(writeToolsEnabled = false).registerManualTools(server)
         toolsResult <- server.listTools()
         tools = toolsResult.tools().asScala.toList
       } yield assertTrue(tools.size == 6)
+    },
+    test("registerManualTools should register update_contact when write tools are enabled") {
+      for {
+        server <- ZIO.succeed(FastMcpServer("TestServer"))
+        _ <- new TestMcpServer(writeToolsEnabled = true).registerManualTools(server)
+        toolsResult <- server.listTools()
+        tools = toolsResult.tools().asScala.toList
+      } yield assertTrue(tools.size == 7) && assertTrue(tools.exists(_.name() == "update_contact"))
     }
   )
+
+  private class TestMcpServer(override protected[server] val writeToolsEnabled: Boolean) extends BaseMcpServer
 }

--- a/src/test/scala/com/zestia/capsulemcp/server/schemas/ContactSchemasSpec.scala
+++ b/src/test/scala/com/zestia/capsulemcp/server/schemas/ContactSchemasSpec.scala
@@ -94,6 +94,64 @@ class ContactSchemasSpec extends AnyFlatSpec with Matchers:
     errors shouldBe Nil
   }
 
+  "ContactSchemas.updateContactSchema" should "produce valid JSON schema" in new ContactSchemasFixture {
+    val errors: List[ValidationError] =
+      updateContactSchema.validate("""{"id": 14, "fields": []}""", InputFormat.JSON).asScala.toList
+
+    errors shouldBe Nil
+  }
+
+  it should "accept a field with a string value" in new ContactSchemasFixture {
+    val body = """{"id": 14, "fields": [{"definition": 135, "value": "some text"}]}"""
+
+    updateContactSchema.validate(body, InputFormat.JSON).asScala.toList shouldBe Nil
+  }
+
+  it should "accept a field with a boolean value" in new ContactSchemasFixture {
+    val body = """{"id": 14, "fields": [{"definition": 135, "value": true}]}"""
+
+    updateContactSchema.validate(body, InputFormat.JSON).asScala.toList shouldBe Nil
+  }
+
+  it should "accept a field with a number value" in new ContactSchemasFixture {
+    val body = """{"id": 14, "fields": [{"definition": 135, "value": 42}]}"""
+
+    updateContactSchema.validate(body, InputFormat.JSON).asScala.toList shouldBe Nil
+  }
+
+  it should "reject a body missing id" in new ContactSchemasFixture {
+    val body = """{"fields": [{"definition": 135, "value": "test"}]}"""
+
+    val errors: List[ValidationError] = updateContactSchema.validate(body, InputFormat.JSON).asScala.toList
+
+    errors should not be Nil
+  }
+
+  it should "reject a body missing fields" in new ContactSchemasFixture {
+    val body = """{"id": 14}"""
+
+    val errors: List[ValidationError] = updateContactSchema.validate(body, InputFormat.JSON).asScala.toList
+
+    errors should not be Nil
+  }
+
+  it should "reject a field item missing definition" in new ContactSchemasFixture {
+    val body = """{"id": 14, "fields": [{"value": "test"}]}"""
+
+    val errors: List[ValidationError] = updateContactSchema.validate(body, InputFormat.JSON).asScala.toList
+
+    errors should not be Nil
+  }
+
+  it should "reject a field item missing value" in new ContactSchemasFixture {
+    val body = """{"id": 14, "fields": [{"definition": 135}]}"""
+
+    val errors: List[ValidationError] = updateContactSchema.validate(body, InputFormat.JSON).asScala.toList
+
+    errors should not be Nil
+  }
+
 private trait ContactSchemasFixture:
   private val schemaRegistry = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_7)
   protected val filterSchema: Schema = schemaRegistry.getSchema(ContactSchemas.filterSchema)
+  protected val updateContactSchema: Schema = schemaRegistry.getSchema(ContactSchemas.updateContactSchema)

--- a/src/test/scala/com/zestia/capsulemcp/service/CapsuleHttpClientSpec.scala
+++ b/src/test/scala/com/zestia/capsulemcp/service/CapsuleHttpClientSpec.scala
@@ -1,13 +1,13 @@
 package com.zestia.capsulemcp.service
 
-import com.zestia.capsulemcp.model.{ContactListWrapper, Pagination}
+import com.zestia.capsulemcp.model.{ActivityListWrapper, ContactListWrapper, ContactWrapper, Pagination}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.client3.testing.SttpBackendStub
-import sttp.client3.{Empty, HttpClientSyncBackend, Identity, RequestT, StringBody, SttpBackend}
-import sttp.model.{Header, Uri}
+import sttp.client3.{Empty, HttpClientSyncBackend, Identity, RequestT, Response, StringBody, SttpBackend}
+import sttp.model.{Header, StatusCode, Uri}
 import com.zestia.capsulemcp.model.filter.{Filter, NumberCondition}
-import com.zestia.capsulemcp.model.ActivityListWrapper
+import zio.json.JsonEncoder
 
 class CapsuleHttpClientSpec extends AnyFlatSpec with Matchers:
 
@@ -177,6 +177,44 @@ class CapsuleHttpClientSpec extends AnyFlatSpec with Matchers:
     // then
     wrapper.response.activities should have size 1
   }
+
+  "putRequest" should "successfully send a PUT request and deserialize the response" in {
+    // given
+    val mockResponse = """{"party": {"id": 14, "type": "person"}}"""
+
+    val backend = SttpBackendStub.synchronous
+      .whenRequestMatches { request =>
+        request.uri.toString.contains("https://api.example.com/api/v2/parties/14") &&
+        request.method.method == "PUT" &&
+        request.headers.find(_.name == "Authorization").get.value == "Bearer api-token"
+      }
+      .thenRespond(mockResponse)
+
+    val client = new TestCapsuleHttpClient(backend)
+
+    // when
+    val wrapper = client.putRequest[ContactWrapper, TestBody]("parties/14", TestBody("test"))
+
+    // then
+    wrapper.response.party.id shouldBe 14
+  }
+
+  it should "throw a write permission error on a 403 response" in {
+    // given
+    val backend = SttpBackendStub.synchronous.whenAnyRequest
+      .thenRespond(Response("""{"message": "Requires additional scope"}""", StatusCode.Forbidden))
+
+    val client = new TestCapsuleHttpClient(backend)
+
+    // when/then
+    val ex = intercept[RuntimeException] {
+      client.putRequest[ContactWrapper, TestBody]("parties/14", TestBody("test"))
+    }
+
+    ex.getMessage should include("write permission")
+  }
+
+  private case class TestBody(value: String) derives JsonEncoder
 
   private class TestCapsuleHttpClient(protected val backend: SttpBackend[Identity, Any]) extends BaseCapsuleHttpClient:
     override protected val apiToken = "api-token"


### PR DESCRIPTION
* Support updating Contact/Project/Opportunity Custom Fields - current opt-in only when env variable `ENABLE_WRITE_TOOLS` is `true`, defaults to `false`
* Update `fast-mcp-scala` to `3.1.0` and scala to `3.8.3`
* Add `tools.jackson.core` as a direct dependency
* Add appropriate Tool annotations (readOnlyHint, idempotentHint, destructiveHint, openWorldHint)
* Add scalafix linter
* Add explicit handling for 403 requires additional scope error from Capsule API
